### PR TITLE
fix: use current vim executable to run tests

### DIFF
--- a/lua/neotest-plenary/init.lua
+++ b/lua/neotest-plenary/init.lua
@@ -97,7 +97,7 @@ function PlenaryNeotestAdapter.build_spec(args)
   end
 
   local command = vim.tbl_flatten({
-    "nvim",
+    vim.loop.exepath(),
     "--headless",
     "-u",
     min_init or "NONE",


### PR DESCRIPTION
There's no guarantee that the current nvim executable is named `nvim`, or is even in the PATH. I keep multiple namespaced versions of nvim so I can test with them.

## Test plan

Opened a neovim test file
Run it with neotest
It still works!